### PR TITLE
Support `INSERT INTO ... DEFAULT VALUES ...`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1385,7 +1385,7 @@ pub enum Statement {
         /// Overwrite (Hive)
         overwrite: bool,
         /// A SQL query that specifies what to insert
-        source: Box<Query>,
+        source: Option<Box<Query>>,
         /// partitioned insert (Hive)
         partitioned: Option<Vec<Expr>>,
         /// Columns defined after PARTITION
@@ -2241,7 +2241,14 @@ impl fmt::Display for Statement {
                 if !after_columns.is_empty() {
                     write!(f, "({}) ", display_comma_separated(after_columns))?;
                 }
-                write!(f, "{source}")?;
+
+                if let Some(source) = source {
+                    write!(f, "{source}")?;
+                }
+
+                if source.is_none() && columns.is_empty() {
+                    write!(f, "DEFAULT VALUES")?;
+                }
 
                 if let Some(on) = on {
                     write!(f, "{on}")?;

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -937,7 +937,7 @@ fn parse_simple_insert() {
             assert_eq!(vec![Ident::new("title"), Ident::new("priority")], columns);
             assert!(on.is_none());
             assert_eq!(
-                Box::new(Query {
+                Some(Box::new(Query {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
@@ -964,7 +964,7 @@ fn parse_simple_insert() {
                     offset: None,
                     fetch: None,
                     locks: vec![],
-                }),
+                })),
                 source
             );
         }
@@ -990,7 +990,7 @@ fn parse_ignore_insert() {
             assert!(on.is_none());
             assert!(ignore);
             assert_eq!(
-                Box::new(Query {
+                Some(Box::new(Query {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
@@ -1005,7 +1005,7 @@ fn parse_ignore_insert() {
                     offset: None,
                     fetch: None,
                     locks: vec![]
-                }),
+                })),
                 source
             );
         }
@@ -1029,7 +1029,7 @@ fn parse_empty_row_insert() {
             assert!(columns.is_empty());
             assert!(on.is_none());
             assert_eq!(
-                Box::new(Query {
+                Some(Box::new(Query {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
@@ -1041,7 +1041,7 @@ fn parse_empty_row_insert() {
                     offset: None,
                     fetch: None,
                     locks: vec![],
-                }),
+                })),
                 source
             );
         }
@@ -1077,7 +1077,7 @@ fn parse_insert_with_on_duplicate_update() {
                 columns
             );
             assert_eq!(
-                Box::new(Query {
+                Some(Box::new(Query {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
@@ -1100,7 +1100,7 @@ fn parse_insert_with_on_duplicate_update() {
                     offset: None,
                     fetch: None,
                     locks: vec![],
-                }),
+                })),
                 source
             );
             assert_eq!(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1372,7 +1372,7 @@ fn parse_prepare() {
         Statement::Insert {
             table_name,
             columns,
-            source,
+            source: Some(source),
             ..
         } => {
             assert_eq!(table_name.to_string(), "customers");


### PR DESCRIPTION
This change adds support for `DEFAULT VALUES` in insert statements.

I'm specifically after [Postgres support](https://www.postgresql.org/docs/current/sql-insert.html), but it looks like `DEFAULT VALUES` is part of the [SQL grammar](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#from-default). It looks to be supported by [SQLite](https://www.sqlite.org/lang_insert.html) and [MSSQL](https://learn.microsoft.com/en-us/sql/t-sql/statements/insert-transact-sql?view=sql-server-ver16#d-inserting-data-into-a-table-with-columns-that-have-default-values) at least as well (I haven't tested with these, though). I took a quick look at the MySQL and BigQuery docs and they don't seem support `DEFAULT VALUES` (and there are probably others that I haven't checked as well).

This includes a **breaking change to the AST** that makes the `source` field on `Statement::Insert` optional. This approach is based on the [implementation in Postgres](https://github.com/postgres/postgres/blob/0bc726d95a305ca923b1f284159f40f0d5cf5725/src/backend/parser/gram.y#L12090-L12095) where both `cols` and `selectStmt` (which looks to be the Postgres AST's equivalent to `source`) are empty. I'm not completely sure if this is appropriate for all dialects, so I'm definitely interested in feedback here 🙏 