### PR TITLE
Add support for `AS table_alias` syntax for inserts in Postgres

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1380,6 +1380,8 @@ pub enum Statement {
         /// TABLE
         #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
         table_name: ObjectName,
+        /// AS table_alias (Postgres)
+        table_alias: Option<Ident>,
         /// COLUMNS
         columns: Vec<Ident>,
         /// Overwrite (Hive)
@@ -2213,6 +2215,7 @@ impl fmt::Display for Statement {
                 ignore,
                 into,
                 table_name,
+                table_alias,
                 overwrite,
                 partitioned,
                 columns,
@@ -2234,6 +2237,10 @@ impl fmt::Display for Statement {
                         int = if *into { " INTO" } else { "" },
                         tbl = if *table { " TABLE" } else { "" }
                     )?;
+
+                    if let Some(table_alias) = table_alias {
+                        write!(f, "AS {table_alias} ")?;
+                    }
                 }
                 if !columns.is_empty() {
                     write!(f, "({}) ", display_comma_separated(columns))?;

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3492,3 +3492,18 @@ fn parse_join_constraint_unnest_alias() {
         }]
     );
 }
+
+#[test]
+fn parse_insert_with_table_alias() {
+    match pg().verified_stmt("INSERT INTO table_1 AS t1 (c1) VALUES (1)") {
+        Statement::Insert {
+            table_name,
+            table_alias,
+            ..
+        } => {
+            assert_eq!(table_name, ObjectName(vec!["table_1".into()]));
+            assert_eq!(table_alias, Some(Ident::new("t1")));
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
Adds support for using table aliases in inserts.

