### PR TITLE
Add support for ORDER BY x USING <op> (PostgreSQL)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1380,6 +1380,8 @@ pub enum Statement {
         /// TABLE
         #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
         table_name: ObjectName,
+        /// AS table_alias (Postgres)
+        table_alias: Option<Ident>,
         /// COLUMNS
         columns: Vec<Ident>,
         /// Overwrite (Hive)
@@ -2213,6 +2215,7 @@ impl fmt::Display for Statement {
                 ignore,
                 into,
                 table_name,
+                table_alias,
                 overwrite,
                 partitioned,
                 columns,
@@ -2234,6 +2237,10 @@ impl fmt::Display for Statement {
                         int = if *into { " INTO" } else { "" },
                         tbl = if *table { " TABLE" } else { "" }
                     )?;
+
+                    if let Some(table_alias) = table_alias {
+                        write!(f, "AS {table_alias} ")?;
+                    }
                 }
                 if !columns.is_empty() {
                     write!(f, "({}) ", display_comma_separated(columns))?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1385,7 +1385,7 @@ pub enum Statement {
         /// Overwrite (Hive)
         overwrite: bool,
         /// A SQL query that specifies what to insert
-        source: Box<Query>,
+        source: Option<Box<Query>>,
         /// partitioned insert (Hive)
         partitioned: Option<Vec<Expr>>,
         /// Columns defined after PARTITION
@@ -2241,7 +2241,14 @@ impl fmt::Display for Statement {
                 if !after_columns.is_empty() {
                     write!(f, "({}) ", display_comma_separated(after_columns))?;
                 }
-                write!(f, "{source}")?;
+
+                if let Some(source) = source {
+                    write!(f, "{source}")?;
+                }
+
+                if source.is_none() && columns.is_empty() {
+                    write!(f, "DEFAULT VALUES")?;
+                }
 
                 if let Some(on) = on {
                     write!(f, "{on}")?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1802,8 +1802,11 @@ pub enum Statement {
     },
     /// `COMMIT [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]`
     Commit { chain: bool },
-    /// `ROLLBACK [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]`
-    Rollback { chain: bool },
+    /// `ROLLBACK [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ] [ TO [ SAVEPOINT ] savepoint_name ]`
+    Rollback {
+        chain: bool,
+        savepoint: Option<Ident>,
+    },
     /// CREATE SCHEMA
     CreateSchema {
         /// `<schema name> | AUTHORIZATION <schema authorization identifier>  | <schema name>  AUTHORIZATION <schema authorization identifier>`
@@ -1940,6 +1943,8 @@ pub enum Statement {
     },
     /// SAVEPOINT -- define a new savepoint within the current transaction
     Savepoint { name: Ident },
+    /// RELEASE [ SAVEPOINT ] savepoint_name
+    ReleaseSavepoint { name: Ident },
     // MERGE INTO statement, based on Snowflake. See <https://docs.snowflake.com/en/sql-reference/sql/merge.html>
     Merge {
         // optional INTO keyword
@@ -3079,8 +3084,18 @@ impl fmt::Display for Statement {
             Statement::Commit { chain } => {
                 write!(f, "COMMIT{}", if *chain { " AND CHAIN" } else { "" },)
             }
-            Statement::Rollback { chain } => {
-                write!(f, "ROLLBACK{}", if *chain { " AND CHAIN" } else { "" },)
+            Statement::Rollback { chain, savepoint } => {
+                write!(f, "ROLLBACK")?;
+
+                if *chain {
+                    write!(f, " AND CHAIN")?;
+                }
+
+                if let Some(savepoint) = savepoint {
+                    write!(f, " TO SAVEPOINT {savepoint}")?;
+                }
+
+                Ok(())
             }
             Statement::CreateSchema {
                 schema_name,
@@ -3176,6 +3191,9 @@ impl fmt::Display for Statement {
             Statement::Savepoint { name } => {
                 write!(f, "SAVEPOINT ")?;
                 write!(f, "{name}")
+            }
+            Statement::ReleaseSavepoint { name } => {
+                write!(f, "RELEASE SAVEPOINT {name}")
             }
             Statement::Merge {
                 into,

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -178,3 +178,4 @@ impl fmt::Display for BinaryOperator {
         }
     }
 }
+

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1065,9 +1065,12 @@ pub enum JoinConstraint {
 pub struct OrderByExpr {
     pub expr: Expr,
     /// Optional `ASC` or `DESC`
+    /// TODO: Convert this into an Enum (ASC, DESC, Operator)
     pub asc: Option<bool>,
     /// Optional `NULLS FIRST` or `NULLS LAST`
     pub nulls_first: Option<bool>,
+    /// Optional `USING` operator for ordering (PostgreSQL only)
+    pub using: Option<BinaryOperator>,
 }
 
 impl fmt::Display for OrderByExpr {
@@ -1077,6 +1080,9 @@ impl fmt::Display for OrderByExpr {
             Some(true) => write!(f, " ASC")?,
             Some(false) => write!(f, " DESC")?,
             None => (),
+        }
+        if let Some(ref operator) = self.using {
+            write!(f, " USING {}", operator)?;
         }
         match self.nulls_first {
             Some(true) => write!(f, " NULLS FIRST")?,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6013,6 +6013,22 @@ impl<'a> Parser<'a> {
         Ok(expr)
     }
 
+    pub fn parse_operator(&mut self) -> Option<BinaryOperator> {
+        let token = self.next_token();
+        match token.token {
+            Token::Eq => Some(BinaryOperator::Eq),
+            Token::Neq => Some(BinaryOperator::NotEq),
+            Token::Lt => Some(BinaryOperator::Lt),
+            Token::LtEq => Some(BinaryOperator::LtEq),
+            Token::Gt => Some(BinaryOperator::Gt),
+            _ => None,
+
+            // TODO: Handle all the other operators
+            // Postgres needs it for ORDER BY x USING <op>
+            // CREATE OPERATOR is also currently not supported
+        }
+    }
+
     pub fn parse_set_operator(&mut self, token: &Token) -> Option<SetOperator> {
         match token {
             Token::Word(w) if w.keyword == Keyword::UNION => Some(SetOperator::Union),
@@ -7507,7 +7523,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse an expression, optionally followed by ASC or DESC (used in ORDER BY)
+    /// Parse an expression, optionally followed by ASC, DESC or USING (used in ORDER BY)
     pub fn parse_order_by_expr(&mut self) -> Result<OrderByExpr, ParserError> {
         let expr = self.parse_expr()?;
 
@@ -7515,6 +7531,12 @@ impl<'a> Parser<'a> {
             Some(true)
         } else if self.parse_keyword(Keyword::DESC) {
             Some(false)
+        } else {
+            None
+        };
+
+        let using = if dialect_of!(self is PostgreSqlDialect | GenericDialect) && self.parse_keyword(Keyword::USING) {
+            self.parse_operator()
         } else {
             None
         };
@@ -7531,6 +7553,7 @@ impl<'a> Parser<'a> {
             expr,
             asc,
             nulls_first,
+            using,
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -502,6 +502,7 @@ impl<'a> Parser<'a> {
                 // by at least PostgreSQL and MySQL.
                 Keyword::BEGIN => Ok(self.parse_begin()?),
                 Keyword::SAVEPOINT => Ok(self.parse_savepoint()?),
+                Keyword::RELEASE => Ok(self.parse_release()?),
                 Keyword::COMMIT => Ok(self.parse_commit()?),
                 Keyword::ROLLBACK => Ok(self.parse_rollback()?),
                 Keyword::ASSERT => Ok(self.parse_assert()?),
@@ -745,6 +746,13 @@ impl<'a> Parser<'a> {
     pub fn parse_savepoint(&mut self) -> Result<Statement, ParserError> {
         let name = self.parse_identifier()?;
         Ok(Statement::Savepoint { name })
+    }
+
+    pub fn parse_release(&mut self) -> Result<Statement, ParserError> {
+        let _ = self.parse_keyword(Keyword::SAVEPOINT);
+        let name = self.parse_identifier()?;
+
+        Ok(Statement::ReleaseSavepoint { name })
     }
 
     /// Parse an expression prefix
@@ -7664,9 +7672,10 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_rollback(&mut self) -> Result<Statement, ParserError> {
-        Ok(Statement::Rollback {
-            chain: self.parse_commit_rollback_chain()?,
-        })
+        let chain = self.parse_commit_rollback_chain()?;
+        let savepoint = self.parse_rollback_savepoint()?;
+
+        Ok(Statement::Rollback { chain, savepoint })
     }
 
     pub fn parse_commit_rollback_chain(&mut self) -> Result<bool, ParserError> {
@@ -7677,6 +7686,17 @@ impl<'a> Parser<'a> {
             Ok(chain)
         } else {
             Ok(false)
+        }
+    }
+
+    pub fn parse_rollback_savepoint(&mut self) -> Result<Option<Ident>, ParserError> {
+        if self.parse_keyword(Keyword::TO) {
+            let _ = self.parse_keyword(Keyword::SAVEPOINT);
+            let savepoint = self.parse_identifier()?;
+
+            Ok(Some(savepoint))
+        } else {
+            Ok(None)
         }
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1829,16 +1829,19 @@ fn parse_select_order_by() {
                     expr: Expr::Identifier(Ident::new("lname")),
                     asc: Some(true),
                     nulls_first: None,
+                    using: None,
                 },
                 OrderByExpr {
                     expr: Expr::Identifier(Ident::new("fname")),
                     asc: Some(false),
                     nulls_first: None,
+                    using: None,
                 },
                 OrderByExpr {
                     expr: Expr::Identifier(Ident::new("id")),
                     asc: None,
                     nulls_first: None,
+                    using: None,
                 },
             ],
             select.order_by
@@ -1861,11 +1864,13 @@ fn parse_select_order_by_limit() {
                 expr: Expr::Identifier(Ident::new("lname")),
                 asc: Some(true),
                 nulls_first: None,
+                using: None,
             },
             OrderByExpr {
                 expr: Expr::Identifier(Ident::new("fname")),
                 asc: Some(false),
                 nulls_first: None,
+                using: None,
             },
         ],
         select.order_by
@@ -1884,11 +1889,13 @@ fn parse_select_order_by_nulls_order() {
                 expr: Expr::Identifier(Ident::new("lname")),
                 asc: Some(true),
                 nulls_first: Some(true),
+                using: None,
             },
             OrderByExpr {
                 expr: Expr::Identifier(Ident::new("fname")),
                 asc: Some(false),
                 nulls_first: Some(false),
+                using: None,
             },
         ],
         select.order_by
@@ -1971,6 +1978,7 @@ fn parse_select_qualify() {
                         expr: Expr::Identifier(Ident::new("o")),
                         asc: None,
                         nulls_first: None,
+                        using: None,
                     }],
                     window_frame: None,
                 })),
@@ -2289,6 +2297,7 @@ fn parse_listagg() {
             }),
             asc: None,
             nulls_first: None,
+            using: None,
         },
         OrderByExpr {
             expr: Expr::Identifier(Ident {
@@ -2297,6 +2306,7 @@ fn parse_listagg() {
             }),
             asc: None,
             nulls_first: None,
+            using: None,
         },
     ];
     assert_eq!(
@@ -3648,6 +3658,7 @@ fn parse_window_functions() {
                     expr: Expr::Identifier(Ident::new("dt")),
                     asc: Some(false),
                     nulls_first: None,
+                    using: None,
                 }],
                 window_frame: None,
             })),
@@ -3765,6 +3776,7 @@ fn test_parse_named_window() {
                         }),
                         asc: None,
                         nulls_first: None,
+                        using: None,
                     }],
                     window_frame: None,
                 },
@@ -6372,11 +6384,13 @@ fn parse_create_index() {
             expr: Expr::Identifier(Ident::new("name")),
             asc: None,
             nulls_first: None,
+            using: None,
         },
         OrderByExpr {
             expr: Expr::Identifier(Ident::new("age")),
             asc: Some(false),
             nulls_first: None,
+            using: None,
         },
     ];
     match verified_stmt(sql) {
@@ -6406,11 +6420,13 @@ fn test_create_index_with_using_function() {
             expr: Expr::Identifier(Ident::new("name")),
             asc: None,
             nulls_first: None,
+            using: None,
         },
         OrderByExpr {
             expr: Expr::Identifier(Ident::new("age")),
             asc: Some(false),
             nulls_first: None,
+            using: None,
         },
     ];
     match verified_stmt(sql) {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6228,6 +6228,17 @@ fn parse_commit() {
 }
 
 #[test]
+fn parse_end() {
+    one_statement_parses_to("END AND NO CHAIN", "COMMIT");
+    one_statement_parses_to("END WORK AND NO CHAIN", "COMMIT");
+    one_statement_parses_to("END TRANSACTION AND NO CHAIN", "COMMIT");
+    one_statement_parses_to("END WORK AND CHAIN", "COMMIT AND CHAIN");
+    one_statement_parses_to("END TRANSACTION AND CHAIN", "COMMIT AND CHAIN");
+    one_statement_parses_to("END WORK", "COMMIT");
+    one_statement_parses_to("END TRANSACTION", "COMMIT");
+}
+
+#[test]
 fn parse_rollback() {
     match verified_stmt("ROLLBACK") {
         Statement::Rollback { chain: false } => (),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6230,12 +6230,38 @@ fn parse_commit() {
 #[test]
 fn parse_rollback() {
     match verified_stmt("ROLLBACK") {
-        Statement::Rollback { chain: false } => (),
+        Statement::Rollback {
+            chain: false,
+            savepoint: None,
+        } => (),
         _ => unreachable!(),
     }
 
     match verified_stmt("ROLLBACK AND CHAIN") {
-        Statement::Rollback { chain: true } => (),
+        Statement::Rollback {
+            chain: true,
+            savepoint: None,
+        } => (),
+        _ => unreachable!(),
+    }
+
+    match verified_stmt("ROLLBACK TO SAVEPOINT test1") {
+        Statement::Rollback {
+            chain: false,
+            savepoint,
+        } => {
+            assert_eq!(savepoint, Some(Ident::new("test1")));
+        }
+        _ => unreachable!(),
+    }
+
+    match verified_stmt("ROLLBACK AND CHAIN TO SAVEPOINT test1") {
+        Statement::Rollback {
+            chain: true,
+            savepoint,
+        } => {
+            assert_eq!(savepoint, Some(Ident::new("test1")));
+        }
         _ => unreachable!(),
     }
 
@@ -6246,6 +6272,11 @@ fn parse_rollback() {
     one_statement_parses_to("ROLLBACK TRANSACTION AND CHAIN", "ROLLBACK AND CHAIN");
     one_statement_parses_to("ROLLBACK WORK", "ROLLBACK");
     one_statement_parses_to("ROLLBACK TRANSACTION", "ROLLBACK");
+    one_statement_parses_to("ROLLBACK TO test1", "ROLLBACK TO SAVEPOINT test1");
+    one_statement_parses_to(
+        "ROLLBACK AND CHAIN TO test1",
+        "ROLLBACK AND CHAIN TO SAVEPOINT test1",
+    );
 }
 
 #[test]
@@ -7858,4 +7889,26 @@ fn parse_binary_operators_without_whitespace() {
         "SELECT tbl1.field%tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
         "SELECT tbl1.field % tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
     );
+}
+
+#[test]
+fn test_savepoint() {
+    match verified_stmt("SAVEPOINT test1") {
+        Statement::Savepoint { name } => {
+            assert_eq!(Ident::new("test1"), name);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_release_savepoint() {
+    match verified_stmt("RELEASE SAVEPOINT test1") {
+        Statement::ReleaseSavepoint { name } => {
+            assert_eq!(Ident::new("test1"), name);
+        }
+        _ => unreachable!(),
+    }
+
+    one_statement_parses_to("RELEASE test1", "RELEASE SAVEPOINT test1");
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1386,6 +1386,7 @@ fn parse_delete_with_order_by() {
                     }),
                     asc: Some(false),
                     nulls_first: None,
+                    using: None,
                 }],
                 order_by
             );

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -937,7 +937,7 @@ fn parse_simple_insert() {
             assert_eq!(vec![Ident::new("title"), Ident::new("priority")], columns);
             assert!(on.is_none());
             assert_eq!(
-                Box::new(Query {
+                Some(Box::new(Query {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
@@ -964,7 +964,7 @@ fn parse_simple_insert() {
                     offset: None,
                     fetch: None,
                     locks: vec![],
-                }),
+                })),
                 source
             );
         }
@@ -990,7 +990,7 @@ fn parse_ignore_insert() {
             assert!(on.is_none());
             assert!(ignore);
             assert_eq!(
-                Box::new(Query {
+                Some(Box::new(Query {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
@@ -1005,7 +1005,7 @@ fn parse_ignore_insert() {
                     offset: None,
                     fetch: None,
                     locks: vec![]
-                }),
+                })),
                 source
             );
         }
@@ -1029,7 +1029,7 @@ fn parse_empty_row_insert() {
             assert!(columns.is_empty());
             assert!(on.is_none());
             assert_eq!(
-                Box::new(Query {
+                Some(Box::new(Query {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
@@ -1041,7 +1041,7 @@ fn parse_empty_row_insert() {
                     offset: None,
                     fetch: None,
                     locks: vec![],
-                }),
+                })),
                 source
             );
         }
@@ -1077,7 +1077,7 @@ fn parse_insert_with_on_duplicate_update() {
                 columns
             );
             assert_eq!(
-                Box::new(Query {
+                Some(Box::new(Query {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
@@ -1100,7 +1100,7 @@ fn parse_insert_with_on_duplicate_update() {
                     offset: None,
                     fetch: None,
                     locks: vec![],
-                }),
+                })),
                 source
             );
             assert_eq!(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3507,3 +3507,83 @@ fn parse_insert_with_table_alias() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn parse_select_order_by_using() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name USING >",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: None,
+            nulls_first: None,
+            using: Some(BinaryOperator::Gt),
+        }],
+        select.order_by
+    );
+}
+
+#[test]
+fn parse_select_order_by_asc() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name ASC",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: Some(true),
+            nulls_first: None,
+            using: None,
+        }],
+        select.order_by
+    );
+}
+
+#[test]
+fn parse_select_order_by_desc() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name DESC",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: Some(false),
+            nulls_first: None,
+            using: None,
+        }],
+        select.order_by
+    );
+}
+
+#[test]
+fn parse_select_order_by_desc_nulls_first() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name DESC NULLS FIRST",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: Some(false),
+            nulls_first: Some(true),
+            using: None,
+        }],
+        select.order_by
+    );
+}
+
+#[test]
+fn parse_select_order_by_using_nulls_last() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name USING < NULLS LAST",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: None,
+            nulls_first: Some(false),
+            using: Some(BinaryOperator::Lt),
+        }],
+        select.order_by
+    );
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3492,3 +3492,18 @@ fn parse_join_constraint_unnest_alias() {
         }]
     );
 }
+
+#[test]
+fn parse_insert_with_table_alias() {
+    match pg().verified_stmt("INSERT INTO table_1 AS t1 (c1) VALUES (1)") {
+        Statement::Insert {
+            table_name,
+            table_alias,
+            ..
+        } => {
+            assert_eq!(table_name, ObjectName(vec!["table_1".into()]));
+            assert_eq!(table_alias, Some(Ident::new("t1")));
+        }
+        _ => unreachable!(),
+    }
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2086,16 +2086,6 @@ fn test_transaction_statement() {
 }
 
 #[test]
-fn test_savepoint() {
-    match pg().verified_stmt("SAVEPOINT test1") {
-        Statement::Savepoint { name } => {
-            assert_eq!(Ident::new("test1"), name);
-        }
-        _ => unreachable!(),
-    }
-}
-
-#[test]
 fn test_json() {
     let sql = "SELECT params ->> 'name' FROM events";
     let select = pg().verified_only_select(sql);

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1372,7 +1372,7 @@ fn parse_prepare() {
         Statement::Insert {
             table_name,
             columns,
-            source,
+            source: Some(source),
             ..
         } => {
             assert_eq!(table_name.to_string(), "customers");


### PR DESCRIPTION
Adds support for the `USING` keyword when using `ORDER BY` in PostgreSQL queries. Only handles a handful of binary operators at the moment but I realised that Postgres operators [can be any string of up to 63 valid characters](https://www.postgresql.org/docs/16/sql-createoperator.html)! SqlParser doesn't support that yet, either.