### PR TITLE
Add builtin pg operator

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -225,6 +225,12 @@ pub enum DataType {
     Unspecified,
 }
 
+impl DataType {
+    pub fn new_custom(name: impl Into<ObjectName>, modifiers: Vec<String>) -> Self {
+        DataType::Custom(name.into(), modifiers)
+    }
+}
+
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1437,6 +1437,8 @@ pub enum Statement {
         /// TABLE
         #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
         table_name: ObjectName,
+        /// AS table_alias (Postgres)
+        table_alias: Option<Ident>,
         /// COLUMNS
         columns: Vec<Ident>,
         /// Overwrite (Hive)
@@ -2492,6 +2494,7 @@ impl fmt::Display for Statement {
                 ignore,
                 into,
                 table_name,
+                table_alias,
                 overwrite,
                 partitioned,
                 columns,
@@ -2524,6 +2527,10 @@ impl fmt::Display for Statement {
                         int = if *into { " INTO" } else { "" },
                         tbl = if *table { " TABLE" } else { "" },
                     )?;
+
+                    if let Some(table_alias) = table_alias {
+                        write!(f, "AS {table_alias} ")?;
+                    }
                 }
                 if !columns.is_empty() {
                     write!(f, "({}) ", display_comma_separated(columns))?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -170,6 +170,21 @@ impl fmt::Display for Ident {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct ObjectName(pub Vec<Ident>);
 
+/// Quality of life assistance for devs writing tests.
+/// Useful when needing an object name and you want to just pass a string.
+/// 
+/// ## Example
+/// 
+/// ```
+/// use sqlparser::ast::ObjectName;
+/// let on: ObjectName = "foo.bar".into();
+/// ```
+impl From<&'static str> for ObjectName {
+    fn from(value: &'static str) -> Self {
+        Self(value.split(".").into_iter().map(Ident::from).collect())
+    }
+}
+
 impl fmt::Display for ObjectName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", display_separated(&self.0, "."))

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -178,3 +178,4 @@ impl fmt::Display for BinaryOperator {
         }
     }
 }
+

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -113,6 +113,8 @@ pub enum BinaryOperator {
     MyIntegerDivide,
     /// Support for custom operators (built by parsers outside this crate)
     Custom(String),
+    /// Geodistance operator, e.g. `a <-> b` (PostgreSQL-specific)
+    PGGeoDistance,
     /// Bitwise XOR, e.g. `a # b` (PostgreSQL-specific)
     PGBitwiseXor,
     /// Bitwise shift left, e.g. `a << b` (PostgreSQL-specific)
@@ -163,6 +165,7 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::DuckIntegerDivide => f.write_str("//"),
             BinaryOperator::MyIntegerDivide => f.write_str("DIV"),
             BinaryOperator::Custom(s) => f.write_str(s),
+            BinaryOperator::PGGeoDistance => f.write_str("<->"),
             BinaryOperator::PGBitwiseXor => f.write_str("#"),
             BinaryOperator::PGBitwiseShiftLeft => f.write_str("<<"),
             BinaryOperator::PGBitwiseShiftRight => f.write_str(">>"),

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1114,9 +1114,12 @@ pub enum JoinConstraint {
 pub struct OrderByExpr {
     pub expr: Expr,
     /// Optional `ASC` or `DESC`
+    /// TODO: Convert this into an Enum (ASC, DESC, Operator)
     pub asc: Option<bool>,
     /// Optional `NULLS FIRST` or `NULLS LAST`
     pub nulls_first: Option<bool>,
+    /// Optional `USING` operator for ordering (PostgreSQL only)
+    pub using: Option<BinaryOperator>,
 }
 
 impl fmt::Display for OrderByExpr {
@@ -1126,6 +1129,9 @@ impl fmt::Display for OrderByExpr {
             Some(true) => write!(f, " ASC")?,
             Some(false) => write!(f, " DESC")?,
             None => (),
+        }
+        if let Some(ref operator) = self.using {
+            write!(f, " USING {}", operator)?;
         }
         match self.nulls_first {
             Some(true) => write!(f, " NULLS FIRST")?,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6532,6 +6532,22 @@ impl<'a> Parser<'a> {
         Ok(expr)
     }
 
+    pub fn parse_operator(&mut self) -> Option<BinaryOperator> {
+        let token = self.next_token();
+        match token.token {
+            Token::Eq => Some(BinaryOperator::Eq),
+            Token::Neq => Some(BinaryOperator::NotEq),
+            Token::Lt => Some(BinaryOperator::Lt),
+            Token::LtEq => Some(BinaryOperator::LtEq),
+            Token::Gt => Some(BinaryOperator::Gt),
+            _ => None,
+
+            // TODO: Handle all the other operators
+            // Postgres needs it for ORDER BY x USING <op>
+            // CREATE OPERATOR is also currently not supported
+        }
+    }
+
     pub fn parse_set_operator(&mut self, token: &Token) -> Option<SetOperator> {
         match token {
             Token::Word(w) if w.keyword == Keyword::UNION => Some(SetOperator::Union),
@@ -8132,7 +8148,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse an expression, optionally followed by ASC or DESC (used in ORDER BY)
+    /// Parse an expression, optionally followed by ASC, DESC or USING (used in ORDER BY)
     pub fn parse_order_by_expr(&mut self) -> Result<OrderByExpr, ParserError> {
         let expr = self.parse_expr()?;
 
@@ -8140,6 +8156,12 @@ impl<'a> Parser<'a> {
             Some(true)
         } else if self.parse_keyword(Keyword::DESC) {
             Some(false)
+        } else {
+            None
+        };
+
+        let using = if dialect_of!(self is PostgreSqlDialect | GenericDialect) && self.parse_keyword(Keyword::USING) {
+            self.parse_operator()
         } else {
             None
         };
@@ -8156,6 +8178,7 @@ impl<'a> Parser<'a> {
             expr,
             asc,
             nulls_first,
+            using,
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2219,6 +2219,9 @@ impl<'a> Parser<'a> {
             Token::Overlap if dialect_of!(self is PostgreSqlDialect | GenericDialect) => {
                 Some(BinaryOperator::PGOverlap)
             }
+            Token::BidirectionalArrow if dialect_of!(self is PostgreSqlDialect | GenericDialect) => {
+                Some(BinaryOperator::PGGeoDistance)
+            },
             Token::Tilde => Some(BinaryOperator::PGRegexMatch),
             Token::TildeAsterisk => Some(BinaryOperator::PGRegexIMatch),
             Token::ExclamationMarkTilde => Some(BinaryOperator::PGRegexNotMatch),
@@ -2638,7 +2641,8 @@ impl<'a> Parser<'a> {
             | Token::TildeAsterisk
             | Token::ExclamationMarkTilde
             | Token::ExclamationMarkTildeAsterisk
-            | Token::Spaceship => Ok(20),
+            | Token::Spaceship
+            | Token::BidirectionalArrow => Ok(20),
             Token::Pipe => Ok(21),
             Token::Caret | Token::Sharp | Token::ShiftRight | Token::ShiftLeft => Ok(22),
             Token::Ampersand => Ok(23),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7728,6 +7728,15 @@ impl<'a> Parser<'a> {
             // Hive lets you put table here regardless
             let table = self.parse_keyword(Keyword::TABLE);
             let table_name = self.parse_object_name()?;
+
+            let is_postgresql = dialect_of!(self is PostgreSqlDialect);
+
+            let table_alias = if is_postgresql {
+                self.parse_insert_table_alias()?
+            } else {
+                None
+            };
+
             let is_mysql = dialect_of!(self is MySqlDialect);
 
             let (columns, partitioned, after_columns, source) =
@@ -7801,6 +7810,7 @@ impl<'a> Parser<'a> {
             Ok(Statement::Insert {
                 or,
                 table_name,
+                table_alias,
                 ignore,
                 into,
                 overwrite,
@@ -7826,6 +7836,16 @@ impl<'a> Parser<'a> {
         } else {
             Ok(None)
         }
+    }
+
+    pub fn parse_insert_table_alias(&mut self) -> Result<Option<Ident>, ParserError> {
+        let table_alias = if self.parse_keyword(Keyword::AS) {
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
+
+        Ok(table_alias)
     }
 
     pub fn parse_update(&mut self) -> Result<Statement, ParserError> {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -157,6 +157,20 @@ impl TestedDialects {
         }
     }
 
+    /// Ensures that `sql` parses as a single [`Query`], and that additionally:
+    ///
+    /// 1. parsing `sql` results in the same [`Statement`] as parsing
+    /// `canonical`.
+    ///
+    /// 2. re-serializing the result of parsing `sql` produces the same
+    /// `canonical` sql string
+    pub fn verified_query_with_canonical(&self, sql: &str, canonical: &str) -> Query {
+        match self.one_statement_parses_to(sql, canonical) {
+            Statement::Query(query) => *query,
+            _ => panic!("Expected Query"),
+        }
+    }
+
     /// Ensures that `sql` parses as a single [Select], and that
     /// re-serializing the parse result produces the same `sql`
     /// string (is not modified after a serialization round-trip).

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "visitor")]
 use sqlparser_derive::{Visit, VisitMut};
 
-use crate::ast::DollarQuotedString;
+use crate::{ast::DollarQuotedString, dialect::PostgreSqlDialect};
 use crate::dialect::{
     BigQueryDialect, DuckDbDialect, GenericDialect, HiveDialect, SnowflakeDialect,
 };
@@ -188,6 +188,8 @@ pub enum Token {
     /// for the specified JSON value. Only the first item of the result is taken into
     /// account. If the result is not Boolean, then NULL is returned.
     AtAt,
+    /// Bidirectional arrow <->
+    BidirectionalArrow,
 }
 
 impl fmt::Display for Token {
@@ -262,6 +264,7 @@ impl fmt::Display for Token {
             Token::HashMinus => write!(f, "#-"),
             Token::AtQuestion => write!(f, "@?"),
             Token::AtAt => write!(f, "@@"),
+            Token::BidirectionalArrow => write!(f, "<->"),
         }
     }
 }
@@ -904,6 +907,14 @@ impl<'a> Tokenizer<'a> {
                             match chars.peek() {
                                 Some('>') => self.consume_and_return(chars, Token::Spaceship),
                                 _ => Ok(Some(Token::LtEq)),
+                            }
+                        }
+                        // Handle PostgreSQL's '<->' operator
+                        Some('-') if dialect_of!(self is PostgreSqlDialect | GenericDialect) => {
+                            chars.next();
+                            match chars.peek() {
+                                Some('>') => self.consume_and_return(chars, Token::BidirectionalArrow),
+                                _ => self.tokenizer_error(chars.location(), "Expected '>' after '-'"),
                             }
                         }
                         Some('>') => self.consume_and_return(chars, Token::Neq),
@@ -2040,6 +2051,25 @@ mod tests {
             TokenWithLocation::new(Token::Whitespace(Whitespace::Newline), 1, 10),
             TokenWithLocation::new(Token::Whitespace(Whitespace::Space), 2, 1),
             TokenWithLocation::new(Token::make_word("b", None), 2, 2),
+        ];
+        compare(expected, tokens);
+    }
+
+    #[test]
+    fn tokenize_biderectional_arrow() {
+        let sql = "SELECT a <-> b";
+        let dialect = GenericDialect {};
+        let tokens = Tokenizer::new(&dialect, sql)
+            .tokenize_with_location()
+            .unwrap();
+        let expected = vec![
+            TokenWithLocation::new(Token::make_keyword("SELECT"), 1, 1),
+            TokenWithLocation::new(Token::Whitespace(Whitespace::Space), 1, 7),
+            TokenWithLocation::new(Token::make_word("a", None), 1, 8),
+            TokenWithLocation::new(Token::Whitespace(Whitespace::Space), 1, 9),
+            TokenWithLocation::new(Token::BidirectionalArrow, 1, 10),
+            TokenWithLocation::new(Token::Whitespace(Whitespace::Space), 1, 13),
+            TokenWithLocation::new(Token::make_word("b", None), 1, 14),
         ];
         compare(expected, tokens);
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1881,16 +1881,19 @@ fn parse_select_order_by() {
                     expr: Expr::Identifier(Ident::new("lname")),
                     asc: Some(true),
                     nulls_first: None,
+                    using: None,
                 },
                 OrderByExpr {
                     expr: Expr::Identifier(Ident::new("fname")),
                     asc: Some(false),
                     nulls_first: None,
+                    using: None,
                 },
                 OrderByExpr {
                     expr: Expr::Identifier(Ident::new("id")),
                     asc: None,
                     nulls_first: None,
+                    using: None,
                 },
             ],
             select.order_by
@@ -1913,11 +1916,13 @@ fn parse_select_order_by_limit() {
                 expr: Expr::Identifier(Ident::new("lname")),
                 asc: Some(true),
                 nulls_first: None,
+                using: None,
             },
             OrderByExpr {
                 expr: Expr::Identifier(Ident::new("fname")),
                 asc: Some(false),
                 nulls_first: None,
+                using: None,
             },
         ],
         select.order_by
@@ -1936,11 +1941,13 @@ fn parse_select_order_by_nulls_order() {
                 expr: Expr::Identifier(Ident::new("lname")),
                 asc: Some(true),
                 nulls_first: Some(true),
+                using: None,
             },
             OrderByExpr {
                 expr: Expr::Identifier(Ident::new("fname")),
                 asc: Some(false),
                 nulls_first: Some(false),
+                using: None,
             },
         ],
         select.order_by
@@ -2023,6 +2030,7 @@ fn parse_select_qualify() {
                         expr: Expr::Identifier(Ident::new("o")),
                         asc: None,
                         nulls_first: None,
+                        using: None,
                     }],
                     window_frame: None,
                 })),
@@ -2341,6 +2349,7 @@ fn parse_listagg() {
             }),
             asc: None,
             nulls_first: None,
+            using: None,
         },
         OrderByExpr {
             expr: Expr::Identifier(Ident {
@@ -2349,6 +2358,7 @@ fn parse_listagg() {
             }),
             asc: None,
             nulls_first: None,
+            using: None,
         },
     ];
     assert_eq!(
@@ -3702,6 +3712,7 @@ fn parse_window_functions() {
                     expr: Expr::Identifier(Ident::new("dt")),
                     asc: Some(false),
                     nulls_first: None,
+                    using: None,
                 }],
                 window_frame: None,
             })),
@@ -3819,6 +3830,7 @@ fn test_parse_named_window() {
                         }),
                         asc: None,
                         nulls_first: None,
+                        using: None,
                     }],
                     window_frame: None,
                 },
@@ -6427,11 +6439,13 @@ fn parse_create_index() {
             expr: Expr::Identifier(Ident::new("name")),
             asc: None,
             nulls_first: None,
+            using: None,
         },
         OrderByExpr {
             expr: Expr::Identifier(Ident::new("age")),
             asc: Some(false),
             nulls_first: None,
+            using: None,
         },
     ];
     match verified_stmt(sql) {
@@ -6461,11 +6475,13 @@ fn test_create_index_with_using_function() {
             expr: Expr::Identifier(Ident::new("name")),
             asc: None,
             nulls_first: None,
+            using: None,
         },
         OrderByExpr {
             expr: Expr::Identifier(Ident::new("age")),
             asc: Some(false),
             nulls_first: None,
+            using: None,
         },
     ];
     match verified_stmt(sql) {

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1705,6 +1705,7 @@ fn parse_delete_with_order_by() {
                     }),
                     asc: Some(false),
                     nulls_first: None,
+                    using: None,
                 }],
                 order_by
             );

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3601,3 +3601,18 @@ fn parse_join_constraint_unnest_alias() {
         }]
     );
 }
+
+#[test]
+fn parse_insert_with_table_alias() {
+    match pg().verified_stmt("INSERT INTO table_1 AS t1 (c1) VALUES (1)") {
+        Statement::Insert {
+            table_name,
+            table_alias,
+            ..
+        } => {
+            assert_eq!(table_name, ObjectName(vec!["table_1".into()]));
+            assert_eq!(table_alias, Some(Ident::new("t1")));
+        }
+        _ => unreachable!(),
+    }
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3616,3 +3616,83 @@ fn parse_insert_with_table_alias() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn parse_select_order_by_using() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name USING >",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: None,
+            nulls_first: None,
+            using: Some(BinaryOperator::Gt),
+        }],
+        select.order_by
+    );
+}
+
+#[test]
+fn parse_select_order_by_asc() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name ASC",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: Some(true),
+            nulls_first: None,
+            using: None,
+        }],
+        select.order_by
+    );
+}
+
+#[test]
+fn parse_select_order_by_desc() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name DESC",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: Some(false),
+            nulls_first: None,
+            using: None,
+        }],
+        select.order_by
+    );
+}
+
+#[test]
+fn parse_select_order_by_desc_nulls_first() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name DESC NULLS FIRST",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: Some(false),
+            nulls_first: Some(true),
+            using: None,
+        }],
+        select.order_by
+    );
+}
+
+#[test]
+fn parse_select_order_by_using_nulls_last() {
+    let select = pg().verified_query(
+        "SELECT name, email FROM users ORDER BY name USING < NULLS LAST",
+    );
+    assert_eq!(
+        vec![OrderByExpr {
+            expr: Expr::Identifier(Ident::new("name")),
+            asc: None,
+            nulls_first: Some(false),
+            using: Some(BinaryOperator::Lt),
+        }],
+        select.order_by
+    );
+}


### PR DESCRIPTION
WIP: This branch is based off https://github.com/cipherstash/sqlparser-rs/pull/6 for now. Once that is merged, I'll rebase off main. Then we have to work out how to open PRs upstream.

I've taken the simplest possible approach in this PR. I had contemplated fixing support for custom operators but the `<->` operator is almost always available in Postgres so it might as well be treated like a builtin.