### PR TITLE
Add support for pg specific Truncate options

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1400,6 +1400,15 @@ pub enum Statement {
         partitions: Option<Vec<Expr>>,
         /// TABLE - optional keyword;
         table: bool,
+        /// Postgres-specific option
+        /// TRUNCATE [ TABLE ] [ ONLY ] name
+        only: bool,
+        /// Postgres-specific option
+        /// [ RESTART IDENTITY | CONTINUE IDENTITY ]
+        identity: Option<TruncateIdentityOption>,
+        /// Postgres-specific option
+        /// [ CASCADE | RESTRICT ]
+        cascade: Option<TruncateCascadeOption>,
     },
     /// ```sql
     /// MSCK
@@ -2403,9 +2412,25 @@ impl fmt::Display for Statement {
                 table_name,
                 partitions,
                 table,
+                only,
+                identity,
+                cascade,
             } => {
                 let table = if *table { "TABLE " } else { "" };
-                write!(f, "TRUNCATE {table}{table_name}")?;
+                let only = if *only { "ONLY " } else { "" };
+                write!(f, "TRUNCATE {table}{only}{table_name}")?;
+                if let Some(identity) = identity {
+                    match identity {
+                        TruncateIdentityOption::Restart => write!(f, " RESTART IDENTITY")?,
+                        TruncateIdentityOption::Continue => write!(f, " CONTINUE IDENTITY")?,
+                    }
+                }
+                if let Some(cascade) = cascade {
+                    match cascade {
+                        TruncateCascadeOption::Cascade => write!(f, " CASCADE")?,
+                        TruncateCascadeOption::Restrict => write!(f, " RESTRICT")?,
+                    }
+                }
                 if let Some(ref parts) = partitions {
                     if !parts.is_empty() {
                         write!(f, " PARTITION ({})", display_comma_separated(parts))?;
@@ -3711,6 +3736,26 @@ impl fmt::Display for Statement {
             }
         }
     }
+}
+
+/// PostgreSQL identity option for TRUNCATE table
+/// [ RESTART IDENTITY | CONTINUE IDENTITY ]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum TruncateIdentityOption {
+    Restart,
+    Continue,
+}
+
+/// PostgreSQL cascade option for TRUNCATE table
+/// [ CASCADE | RESTRICT ]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum TruncateCascadeOption {
+    Cascade,
+    Restrict,
 }
 
 /// Can use to describe options in create sequence or table column type identity

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -167,6 +167,7 @@ define_keywords!(
     CONNECTION,
     CONSTRAINT,
     CONTAINS,
+    CONTINUE,
     CONVERT,
     COPY,
     COPY_OPTIONS,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -651,6 +651,8 @@ impl<'a> Parser<'a> {
 
     pub fn parse_truncate(&mut self) -> Result<Statement, ParserError> {
         let table = self.parse_keyword(Keyword::TABLE);
+        let only = self.parse_keyword(Keyword::ONLY);
+
         let table_name = self.parse_object_name()?;
         let mut partitions = None;
         if self.parse_keyword(Keyword::PARTITION) {
@@ -658,10 +660,30 @@ impl<'a> Parser<'a> {
             partitions = Some(self.parse_comma_separated(Parser::parse_expr)?);
             self.expect_token(&Token::RParen)?;
         }
+
+        let identity = if self.parse_keywords(&[Keyword::RESTART, Keyword::IDENTITY]) {
+            Some(TruncateIdentityOption::Restart)
+        } else if self.parse_keywords(&[Keyword::CONTINUE, Keyword::IDENTITY]) {
+            Some(TruncateIdentityOption::Continue)
+        } else {
+            None
+        };
+
+        let cascade = if self.parse_keyword(Keyword::CASCADE) {
+            Some(TruncateCascadeOption::Cascade)
+        } else if self.parse_keyword(Keyword::RESTRICT) {
+            Some(TruncateCascadeOption::Restrict)
+        } else {
+            None
+        };
+
         Ok(Statement::Truncate {
             table_name,
             partitions,
             table,
+            only,
+            identity,
+            cascade,
         })
     }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -570,7 +570,6 @@ fn parse_alter_table_disable() {
     pg_and_generic().verified_stmt("ALTER TABLE tab DISABLE TRIGGER ALL");
     pg_and_generic().verified_stmt("ALTER TABLE tab DISABLE TRIGGER USER");
     pg_and_generic().verified_stmt("ALTER TABLE tab DISABLE TRIGGER trigger_name");
-
 }
 
 #[test]
@@ -3465,7 +3464,27 @@ fn parse_truncate() {
         Statement::Truncate {
             table_name: ObjectName(vec![Ident::new("db"), Ident::new("table_name")]),
             partitions: None,
-            table: false
+            table: false,
+            only: false,
+            identity: None,
+            cascade: None,
+        },
+        truncate
+    );
+}
+
+#[test]
+fn parse_truncate_with_options() {
+    let truncate = pg_and_generic()
+        .verified_stmt("TRUNCATE TABLE ONLY db.table_name RESTART IDENTITY CASCADE");
+    assert_eq!(
+        Statement::Truncate {
+            table_name: ObjectName(vec![Ident::new("db"), Ident::new("table_name")]),
+            partitions: None,
+            table: true,
+            only: true,
+            identity: Some(TruncateIdentityOption::Restart),
+            cascade: Some(TruncateCascadeOption::Cascade)
         },
         truncate
     );


### PR DESCRIPTION
Extended truncate options used by Rails in E2E tests. 

As we parse sql to redact sensitive data, lack of support means errors when logging.


```
TRUNCATE [ TABLE ] [ ONLY ] name [ * ] [, ... ]
    [ RESTART IDENTITY | CONTINUE IDENTITY ] [ CASCADE | RESTRICT ]
```