### PR TITLE
Increase casting precedence to fix binaryop miscast

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -17,8 +17,8 @@
 use std::fs;
 
 use simple_logger::SimpleLogger;
-use sqlparser::dialect::*;
-use sqlparser::parser::Parser;
+use sqlparser42::dialect::*;
+use sqlparser42::parser::Parser;
 
 fn main() {
     SimpleLogger::new().init().unwrap();

--- a/examples/parse_select.rs
+++ b/examples/parse_select.rs
@@ -12,8 +12,8 @@
 
 #![warn(clippy::all)]
 
-use sqlparser::dialect::GenericDialect;
-use sqlparser::parser::*;
+use sqlparser42::dialect::GenericDialect;
+use sqlparser42::parser::*;
 
 fn main() {
     let sql = "SELECT a, b, 123, myfunc(b) \

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2660,7 +2660,6 @@ impl<'a> Parser<'a> {
             Token::Mul | Token::Div | Token::DuckIntDiv | Token::Mod | Token::StringConcat => {
                 Ok(Self::MUL_DIV_MOD_OP_PREC)
             }
-            Token::DoubleColon => Ok(50),
             Token::Colon => Ok(50),
             Token::ExclamationMark => Ok(50),
             Token::LBracket
@@ -2674,6 +2673,7 @@ impl<'a> Parser<'a> {
             | Token::HashMinus
             | Token::AtQuestion
             | Token::AtAt => Ok(50),
+            Token::DoubleColon => Ok(51),
             _ => Ok(0),
         }
     }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -13,12 +13,12 @@
 #[macro_use]
 mod test_utils;
 
-use sqlparser::ast;
+use sqlparser42::ast;
 use std::ops::Deref;
 
-use sqlparser::ast::*;
-use sqlparser::dialect::{BigQueryDialect, GenericDialect};
-use sqlparser::parser::ParserError;
+use sqlparser42::ast::*;
+use sqlparser42::dialect::{BigQueryDialect, GenericDialect};
+use sqlparser42::parser::ParserError;
 use test_utils::*;
 
 #[test]

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -18,14 +18,14 @@ mod test_utils;
 
 use test_utils::*;
 
-use sqlparser::ast::Expr::{BinaryOp, Identifier, MapAccess};
-use sqlparser::ast::Ident;
-use sqlparser::ast::SelectItem::UnnamedExpr;
-use sqlparser::ast::TableFactor::Table;
-use sqlparser::ast::*;
+use sqlparser42::ast::Expr::{BinaryOp, Identifier, MapAccess};
+use sqlparser42::ast::Ident;
+use sqlparser42::ast::SelectItem::UnnamedExpr;
+use sqlparser42::ast::TableFactor::Table;
+use sqlparser42::ast::*;
 
-use sqlparser::dialect::ClickHouseDialect;
-use sqlparser::dialect::GenericDialect;
+use sqlparser42::dialect::ClickHouseDialect;
+use sqlparser42::dialect::GenericDialect;
 
 #[test]
 fn parse_map_access_expr() {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -21,16 +21,16 @@
 extern crate core;
 
 use matches::assert_matches;
-use sqlparser::ast::SelectItem::UnnamedExpr;
-use sqlparser::ast::TableFactor::{Pivot, Unpivot};
-use sqlparser::ast::*;
-use sqlparser::dialect::{
+use sqlparser42::ast::SelectItem::UnnamedExpr;
+use sqlparser42::ast::TableFactor::{Pivot, Unpivot};
+use sqlparser42::ast::*;
+use sqlparser42::dialect::{
     AnsiDialect, BigQueryDialect, ClickHouseDialect, Dialect, DuckDbDialect, GenericDialect,
     HiveDialect, MsSqlDialect, MySqlDialect, PostgreSqlDialect, RedshiftSqlDialect, SQLiteDialect,
     SnowflakeDialect,
 };
-use sqlparser::keywords::ALL_KEYWORDS;
-use sqlparser::parser::{Parser, ParserError, ParserOptions};
+use sqlparser42::keywords::ALL_KEYWORDS;
+use sqlparser42::parser::{Parser, ParserError, ParserOptions};
 use test_utils::{
     all_dialects, alter_table_op, assert_eq_vec, expr_from_projection, join, number, only, table,
     table_alias, TestedDialects,
@@ -158,7 +158,6 @@ fn parse_insert_default_values() {
             table_name,
             ..
         } => {
-
             assert_eq!(after_columns, vec![]);
             assert_eq!(columns, vec![]);
             assert_eq!(on, None);

--- a/tests/sqlparser_custom_dialect.rs
+++ b/tests/sqlparser_custom_dialect.rs
@@ -12,7 +12,7 @@
 
 //! Test the ability for dialects to override parsing
 
-use sqlparser::{
+use sqlparser42::{
     ast::{BinaryOperator, Expr, Statement, Value},
     dialect::Dialect,
     keywords::Keyword,

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -15,8 +15,8 @@ mod test_utils;
 
 use test_utils::*;
 
-use sqlparser::ast::*;
-use sqlparser::dialect::{DuckDbDialect, GenericDialect};
+use sqlparser42::ast::*;
+use sqlparser42::dialect::{DuckDbDialect, GenericDialect};
 
 fn duckdb() -> TestedDialects {
     TestedDialects {

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -15,13 +15,13 @@
 //! Test SQL syntax specific to Hive. The parser based on the generic dialect
 //! is also tested (on the inputs it can handle).
 
-use sqlparser::ast::{
+use sqlparser42::ast::{
     CreateFunctionBody, CreateFunctionUsing, Expr, Function, FunctionDefinition, Ident, ObjectName,
     SelectItem, Statement, TableFactor, UnaryOperator, Value,
 };
-use sqlparser::dialect::{GenericDialect, HiveDialect};
-use sqlparser::parser::{ParserError, ParserOptions};
-use sqlparser::test_utils::*;
+use sqlparser42::dialect::{GenericDialect, HiveDialect};
+use sqlparser42::parser::{ParserError, ParserOptions};
+use sqlparser42::test_utils::*;
 
 #[test]
 fn parse_table_create() {

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -18,8 +18,8 @@
 mod test_utils;
 use test_utils::*;
 
-use sqlparser::ast::*;
-use sqlparser::dialect::{GenericDialect, MsSqlDialect};
+use sqlparser42::ast::*;
+use sqlparser42::dialect::{GenericDialect, MsSqlDialect};
 
 #[test]
 fn parse_mssql_identifiers() {

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -15,13 +15,13 @@
 //! is also tested (on the inputs it can handle).
 
 use matches::assert_matches;
-use sqlparser::ast::Expr;
-use sqlparser::ast::MysqlInsertPriority::{Delayed, HighPriority, LowPriority};
-use sqlparser::ast::Value;
-use sqlparser::ast::*;
-use sqlparser::dialect::{GenericDialect, MySqlDialect};
-use sqlparser::parser::ParserOptions;
-use sqlparser::tokenizer::Token;
+use sqlparser42::ast::Expr;
+use sqlparser42::ast::MysqlInsertPriority::{Delayed, HighPriority, LowPriority};
+use sqlparser42::ast::Value;
+use sqlparser42::ast::*;
+use sqlparser42::dialect::{GenericDialect, MySqlDialect};
+use sqlparser42::parser::ParserOptions;
+use sqlparser42::tokenizer::Token;
 use test_utils::*;
 
 #[macro_use]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3754,3 +3754,27 @@ fn parse_query_with_biderectional_arrow() {
         select.order_by
     );
 }
+
+#[test]
+fn parse_cast_text_array() {
+    pg_and_generic().verified_only_select_with_canonical(
+        "SELECT ARRAY ['vtha']::TEXT[];",
+        "SELECT CAST(ARRAY['vtha'] AS TEXT[])",
+    );
+}
+
+#[test]
+fn parse_cast_compare_text_array() {
+    pg_and_generic().verified_only_select_with_canonical(
+        "SELECT * FROM users WHERE roles && ARRAY ['vtha']::TEXT[];",
+        "SELECT * FROM users WHERE roles && CAST(ARRAY['vtha'] AS TEXT[])",
+    );
+}
+
+#[test]
+fn parse_cast_basic() {
+    pg_and_generic().verified_only_select_with_canonical(
+        "SELECT '100'::integer",
+        "SELECT CAST('100' AS INTEGER)",
+    );
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -18,9 +18,9 @@
 mod test_utils;
 use test_utils::*;
 
-use sqlparser::ast::*;
-use sqlparser::dialect::{GenericDialect, PostgreSqlDialect};
-use sqlparser::parser::ParserError;
+use sqlparser42::ast::*;
+use sqlparser42::dialect::{GenericDialect, PostgreSqlDialect};
+use sqlparser42::parser::ParserError;
 
 #[test]
 fn parse_create_table_generated_always_as_identity() {
@@ -1883,7 +1883,7 @@ fn parse_array_index_expr() {
     let sql = "SELECT ARRAY[]";
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
-        &Expr::Array(sqlparser::ast::Array {
+        &Expr::Array(Array {
             elem: vec![],
             named: true
         }),

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -15,9 +15,9 @@ mod test_utils;
 
 use test_utils::*;
 
-use sqlparser::ast::*;
-use sqlparser::dialect::GenericDialect;
-use sqlparser::dialect::RedshiftSqlDialect;
+use sqlparser42::ast::*;
+use sqlparser42::dialect::GenericDialect;
+use sqlparser42::dialect::RedshiftSqlDialect;
 
 #[test]
 fn test_square_brackets_over_db_schema_table_name() {

--- a/tests/sqlparser_regression.rs
+++ b/tests/sqlparser_regression.rs
@@ -12,8 +12,8 @@
 
 #![warn(clippy::all)]
 
-use sqlparser::dialect::GenericDialect;
-use sqlparser::parser::Parser;
+use sqlparser42::dialect::GenericDialect;
+use sqlparser42::parser::Parser;
 
 macro_rules! tpch_tests {
     ($($name:ident: $value:expr,)*) => {

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -14,13 +14,13 @@
 //! Test SQL syntax specific to Snowflake. The parser based on the
 //! generic dialect is also tested (on the inputs it can handle).
 
-use sqlparser::ast::helpers::stmt_data_loading::{
+use sqlparser42::ast::helpers::stmt_data_loading::{
     DataLoadingOption, DataLoadingOptionType, StageLoadSelectItem,
 };
-use sqlparser::ast::*;
-use sqlparser::dialect::{GenericDialect, SnowflakeDialect};
-use sqlparser::parser::ParserError;
-use sqlparser::tokenizer::*;
+use sqlparser42::ast::*;
+use sqlparser42::dialect::{GenericDialect, SnowflakeDialect};
+use sqlparser42::parser::ParserError;
+use sqlparser42::tokenizer::*;
 use test_utils::*;
 
 #[macro_use]

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -19,11 +19,11 @@ mod test_utils;
 
 use test_utils::*;
 
-use sqlparser::ast::SelectItem::UnnamedExpr;
-use sqlparser::ast::*;
-use sqlparser::dialect::{GenericDialect, SQLiteDialect};
-use sqlparser::parser::{ParserError, ParserOptions};
-use sqlparser::tokenizer::Token;
+use sqlparser42::ast::SelectItem::UnnamedExpr;
+use sqlparser42::ast::*;
+use sqlparser42::dialect::{GenericDialect, SQLiteDialect};
+use sqlparser42::parser::{ParserError, ParserOptions};
+use sqlparser42::tokenizer::Token;
 
 #[test]
 fn pragma_no_value() {

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 // Re-export everything from `src/test_utils.rs`.
-pub use sqlparser::test_utils::*;
+pub use sqlparser42::test_utils::*;
 
 // For the test-only macros we take a different approach of keeping them here
 // rather than in the library crate.


### PR DESCRIPTION
Perx issue caused by applying casting to the parent expression. 